### PR TITLE
Change battle sort order values from 0,1,2... to 10,20,30...

### DIFF
--- a/client/files/content/scripts/5-battle.js
+++ b/client/files/content/scripts/5-battle.js
@@ -99,7 +99,7 @@ function battleSaveTemplate()
 {
 	try {
 		var sortOrder = {}, savePacket = {}, sortedPacket = {};
-		battleWindow.sBody().find('[type=checkbox]').each(function(i, item) { sortOrder[item.id] = { 'order': i, 'time': parseInt($(item).closest("div.row").find("select").val()) }; });
+		battleWindow.sBody().find('[type=checkbox]').each(function(i, item) { sortOrder[item.id] = { 'order': (i + 1) * 10, 'time': parseInt($(item).closest("div.row").find("select").val()) }; });
 		battleWindow.withBody('[type=checkbox]:checked').each(function(i, item) {
 			var spec = armyGetSpecialistFromID(item.id);
 			savePacket[item.id] = { 


### PR DESCRIPTION
The only purpose of this change is to make manual templates editing easer.
When numbering is 0,1,2,3 - if you insert smth in the beginning or the middle you have to reorder all subsequent items.
If order is 10,20,30 - you have gaps.