### PR TITLE
Add null check in getImage function

### DIFF
--- a/client/files/content/scripts/0-common.js
+++ b/client/files/content/scripts/0-common.js
@@ -491,6 +491,11 @@ var Utils = function() {
 };
 Utils.prototype = {
     getImage: function(t, e, a) {
+        if (!t) {
+            return $("<span>", {
+                'style': "display: inline-block; width: {0}; height: {1}; background-color: #ccc;".format(e || "auto", a || "auto")
+            }).prop("outerHTML");
+        }
         var r = t.encode(t.rect, this.pngOpts);
         return this.b64.encodeBytes(r), $("<img>", {
                 'style': "width: {0};height: {1};".format(e || "auto", a || "auto"),


### PR DESCRIPTION
## Summary
- Add null check to prevent errors when bitmap data parameter is null/undefined
- Return placeholder gray span element instead of attempting to encode null value

## Test plan
- Verify that getImage handles null input gracefully without throwing errors
- Confirm placeholder element is displayed with correct dimensions