### PR TITLE
Fix critical memory leaks in intervals and timeouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 packages
 client/bin
 client/obj
+_temp

--- a/client/files/content/scripts/0-common.js
+++ b/client/files/content/scripts/0-common.js
@@ -1,4 +1,5 @@
 var forcegcIntervalId = null;
+var memMonitorIntervalId = null;
 var enabledScripts = {};
 var buiFastAccess = [];
 var lruTemplate = {};
@@ -79,6 +80,20 @@ function toggleExperimental()
 
 function reloadScripts(event)
 {
+	// Clean up intervals before reloading scripts
+	if(forcegcIntervalId) {
+		clearInterval(forcegcIntervalId);
+		forcegcIntervalId = null;
+	}
+	if(memMonitorIntervalId) {
+		clearInterval(memMonitorIntervalId);
+		memMonitorIntervalId = null;
+	}
+	if(dropbox && dropbox.refreshIntervalId) {
+		clearInterval(dropbox.refreshIntervalId);
+		dropbox.refreshIntervalId = null;
+	}
+
 	menu.clearTools();
 	air.File.applicationDirectory.resolvePath("userscripts").getDirectoryListing().forEach(function(item) {
 		if(enabledScripts[item.name] || enabledScripts[item.name] == undefined) {

--- a/client/files/content/scripts/99-menu.js
+++ b/client/files/content/scripts/99-menu.js
@@ -224,6 +224,7 @@ Menu.prototype = {
 };
 menu = new Menu(mainSettings.menuStyle);
 menu.show();
-setInterval(function() { menu.nativeMenu.getItemByName("memusage").label = 'Mem: ' + humanMemorySize(air.System.privateMemory, 1); }, 5000);
+if(memMonitorIntervalId) clearInterval(memMonitorIntervalId);
+memMonitorIntervalId = setInterval(function() { menu.nativeMenu.getItemByName("memusage").label = 'Mem: ' + humanMemorySize(air.System.privateMemory, 1); }, 5000);
 reloadScripts(null);
 shortcutsMakeMenu();

--- a/userscripts/user_buildlist.js
+++ b/userscripts/user_buildlist.js
@@ -148,11 +148,14 @@ var _exudBuildingMonitorSettings = {
 };
 $.extend(_exudBuildingMonitorSettings, readSettings(null, 'exusMonitorBuilding'));
 
+// Clean up any existing timeout before initialization
+if (typeof _exudBuildingMonitorTimeOut !== 'undefined' && _exudBuildingMonitorTimeOut != null) {
+	clearTimeout(_exudBuildingMonitorTimeOut);
+}
 var _exudBuildingMonitorTimeOut = null;
 
-if ((_exudBuildingMonitorTimeOut == null || _exudBuildingMonitorTimeOut == undefined) && (_exudBuildingMonitorSettings.Notify))
+if (_exudBuildingMonitorSettings.Notify)
 {
-	_exudBuildingMonitorTimeOut = null;
 	setTimeout(_exudUserBuildingMonitorStart, 30000);
 }
 


### PR DESCRIPTION
## Summary
- Clean up intervals and timeouts before script reload to prevent memory leaks
- Store interval IDs globally so they can be properly cleared
- Fix building monitor timeout leak from recursive timeout chain

## Critical Issues Fixed

### 1. Force GC and Dropbox Refresh Interval Cleanup
- Added cleanup in `reloadScripts()` to clear `forcegcIntervalId` and `dropbox.refreshIntervalId`
- Prevents multiple timers running after script reload

### 2. Memory Monitor Interval Leak
- Added global variable `memMonitorIntervalId` to store interval reference
- Clear existing interval before creating new one
- Prevents accumulation of memory monitor intervals

### 3. Building Monitor Timeout Leak
- Clear any existing timeout before script initialization in `user_buildlist.js`
- Prevents multiple recursive timeout chains from running simultaneously
- Fixes issue where old timeouts continue running with stale references after script reload

## Additional Changes
- Added `_temp` directory to `.gitignore` for temporary files

## Test plan
- Test script reload functionality multiple times
- Verify no duplicate timers are running after reload
- Monitor memory usage over extended sessions
- Confirm building monitor doesn't create multiple timeout chains