### PR TITLE
🔧 fix: Toggle Title messages when switched.

### DIFF
--- a/userscripts/user_drunken_miner.js
+++ b/userscripts/user_drunken_miner.js
@@ -67,9 +67,9 @@
 
     const DM_lements        = {
         ON_OFF_RADIO: SCRIPT_PREFIX + 'StateSwitch',
-        ON_OFF_RADIO_TEXT: SCRIPT_PREFIX + 'StateSwitchStatus',
+        ON_OFF_RADIO_TEXT: SCRIPT_PREFIX + 'StateSwitch_TEXT',
         ON_OFF_AUTOMODE_RADIO: SCRIPT_PREFIX + 'AutoModeStateSwitch',
-        ON_OFF_AUTOMODE_RADIO_TEXT: SCRIPT_PREFIX + 'AutoModeStateSwitchStatus',
+        ON_OFF_AUTOMODE_RADIO_TEXT: SCRIPT_PREFIX + 'AutoModeStateSwitch_TEXT',
         BUILD_CHECKBX: SCRIPT_PREFIX + 'buildCheckBox',
         UPGR_CHECKBX: SCRIPT_PREFIX + 'upgrCheckBox',
         SAFE_BUFF_BTN: SCRIPT_PREFIX + 'toggleSafeBuffing',


### PR DESCRIPTION
<img width="568" height="84" alt="image" src="https://github.com/user-attachments/assets/024f7006-de66-4d5e-96f6-68c5264a5c24" />

Fixed display of labels when switching modes