### PR TITLE
🔧 fix: save settings after adding new trade

### DIFF
--- a/userscripts/user_shortcut_trader.js
+++ b/userscripts/user_shortcut_trader.js
@@ -236,6 +236,7 @@ var ShortcutTrader = (function () {
             };
 
             SettingsService.getCurrentTrades().push(newTrade);
+            SettingsService.saveSettings();
             UIRenderer.renderBody();
         }
 


### PR DESCRIPTION
Fix: Resolved an issue where newly added trades were not persisted and were lost after script restart.