### PR TITLE
🔧 fix (Shortcut trader) : Fix with hotkeys & settings initializing

### DIFF
--- a/userscripts/user_shortcut_trader.js
+++ b/userscripts/user_shortcut_trader.js
@@ -15,7 +15,7 @@ var ShortcutTrader = (function () {
     };
     var buildTemplates;
 
-    function openModal() {
+    function OpenShortCutTraderModal() {
         try {
             if (!game.gi.isOnHomzone()) {
                 game.showAlert(getText('not_home'));
@@ -65,7 +65,8 @@ var ShortcutTrader = (function () {
         try {
             game.gi.mClientMessages.SendMessagetoServer(SCRIPT_CONST.MESSAGE_TYPES.REQUEST_TRADE_DATA, game.gi.mCurrentViewedZoneID, null)
             $.extend(SettingsService.getState().tradesData, settings.read(null, SCRIPT_CONST.PREFIX + '_SETTINGS'));
-            addToolsMenuItem(SCRIPT_CONST.NAME, openModal);
+            window.OpenShortCutTraderModal = OpenShortCutTraderModal
+            addToolsMenuItem(SCRIPT_CONST.NAME, window.OpenShortCutTraderModal);
         } catch (e) {
             debug(e);
         }
@@ -905,15 +906,7 @@ var ShortcutTrader = (function () {
         }
     };
 
-    return {
-        init: init,
-        TradeService: TradeService,
-        TradeValidator: TradeValidator,
-        TradeOfferFactory: TradeOfferFactory,
-        TradeResources: TradeResources,
-        TradeQueue: TradeQueue,
-        TradeUI: TradeUI,
-    };
+    return { init:init, openModal:OpenShortCutTraderModal };
 })();
 
 ShortcutTrader.init();


### PR DESCRIPTION
Previously, the script could not be triggered using hotkeys, and settings were not loaded when open the script. This update fixes both issues: hotkeys now work correctly, and settings now loading properly.