### PR TITLE
🔧 fix(scripts): filter directory listing to load only js files

### DIFF
--- a/client/files/content/scripts/0-common.js
+++ b/client/files/content/scripts/0-common.js
@@ -81,6 +81,7 @@ function reloadScripts(event)
 {
 	menu.clearTools();
 	air.File.applicationDirectory.resolvePath("userscripts").getDirectoryListing().forEach(function(item) {
+		if (item.isDirectory || item.name.match(/\.js$/i) === null) { return; }
 		if(enabledScripts[item.name] || enabledScripts[item.name] == undefined) {
 			$('head').append($("<script>").attr({ "src": "userscripts/" + item.name + "?" + new Date().getTime(), "id": "user", "type": "text/javascript"}));
 		}


### PR DESCRIPTION
### Problem

`reloadScripts()` in `client/files/content/scripts/0-common.js` iterates the whole
`userscripts` directory and injects **every** entry as a `<script type="text/javascript">`,
with no extension check:

```js
air.File.applicationDirectory.resolvePath("userscripts").getDirectoryListing().forEach(function(item) {
    if(enabledScripts[item.name] || enabledScripts[item.name] == undefined) {
        $('head').append($("<script>").attr({ "src": "userscripts/" + item.name + ... }));
    }
});
```

Since `userscripts/` also contains `README.md` and `info.json`, both files are loaded
as JavaScript. This produces two parse errors in the AIR debug console on every
Tools -> Reload, and after every install/remove in the script manager
(`finishProceed()` -> `reloadScripts(null)`).

Side effect: `README.md` and `info.json` can end up as entries in `enabledScripts`
and get persisted into settings as if they were userscripts.

### Why this looks like an oversight

`getCurrentScripts()` in `0-manager.js` already does exactly this filtering:

```js
if (item.name !== "99-example.js" && item.name.match(/\.js$/i) !== null) { ... }
```

It was introduced in d099b5e ("Exclude non-js files and folders from scripts list"),
but the same guard was never applied to `reloadScripts()`.

### Fix

Skip directories and non-`.js` entries in `reloadScripts()`, consistent with
`getCurrentScripts()`. No behaviour change for actual userscripts.

### Testing

- Launched the client with `--debug`: no parse errors on Tools -> Reload, previously two.
- Userscripts still load, and enable/disable plus install/remove in the manager work as before.